### PR TITLE
element on linkedin website changed name resulting in scraper failing with no jobs found

### DIFF
--- a/linkedin_jobs_scraper/linkedin_scraper.py
+++ b/linkedin_jobs_scraper/linkedin_scraper.py
@@ -129,13 +129,16 @@ class LinkedinScraper:
 
             # Remote filter supported only with authenticated session (for now)
             if query.options.filters.remote is not None and Config.LI_AT_COOKIE:
-                params['f_WRA'] = query.options.filters.remote.value
+                # Seems like the remote parameter changed to f_WT?
+                # 2%2C3 = Remote + Hybrid
+                params['f_WT'] = '2%2C3'
                 debug(tag, 'Applied remote filter', query.options.filters.remote)
 
             # Start offset
             params['start'] = '0'
 
-        parsed = parsed._replace(query=urlencode(params))
+        # Need to specify % as safe character else the filter won't work
+        parsed = parsed._replace(query=urlencode(params, safe='%'))
         return parsed.geturl()
 
     def __run(self, query: Query) -> None:

--- a/linkedin_jobs_scraper/strategies/authenticated_strategy.py
+++ b/linkedin_jobs_scraper/strategies/authenticated_strategy.py
@@ -281,6 +281,9 @@ class AuthenticatedStrategy(Strategy):
             warn(tag, 'No jobs found, skip')
             return
 
+        # Seems to fix error where scraper reaches only up to the 7th result on 1st page
+        driver.execute_script('''window.scrollTo(0, document.body.scrollHeight);''')
+
         # Pagination loop
         while metrics.processed < query.options.limit:
             # Verify session in loop

--- a/linkedin_jobs_scraper/strategies/authenticated_strategy.py
+++ b/linkedin_jobs_scraper/strategies/authenticated_strategy.py
@@ -21,7 +21,7 @@ from ..exceptions import InvalidCookieException
 
 
 class Selectors(NamedTuple):
-    container = '.jobs-search-two-pane__results'
+    container = '.scaffold-layout__list-container'
     chatPanel = '.msg-overlay-list-bubble'
     jobs = 'div.job-card-container'
     link = 'a.job-card-container__link'


### PR DESCRIPTION
```
        # Wait container
        try:
            WebDriverWait(driver, 5).until(ec.presence_of_element_located((By.CSS_SELECTOR, Selectors.container)))
        except BaseException as e:
            warn(tag, 'No jobs found, skip')
            return
```

tracked down the error to the above lines in `authenticated_strategy.py`. looks like linkedin changed the elements classname.