### PR TITLE
Refactored callback validation to use callable() for broader compatibility.

### DIFF
--- a/linkedin_jobs_scraper/linkedin_scraper.py
+++ b/linkedin_jobs_scraper/linkedin_scraper.py
@@ -256,7 +256,7 @@ class LinkedinScraper:
         if not isinstance(event, Events):
             raise ValueError(f'Event must be an instance of enum class Events')
 
-        if not isinstance(cb, FunctionType):
+        if not callable(cb):
             raise ValueError('Callback must be a function')
 
         if event == Events.DATA or event == Events.ERROR or event == Events.METRICS:


### PR DESCRIPTION
At the moment, `LinkedinScraper.on` method doesn't allow class methods to be passed as a callback.
Example:
```python
class A:
    def __init__(self):
        self.scraper = LinkedinScraper(...)
        self.scraper.on(..., self.callback)

     def callback(self):
          ...
```
This code fails with `ValueError: Callback must be a function`.

 This PR proposes utilising Python's `callable` method instead of checking whether callback is an instance of `FunctionType`.