### PR TITLE
Change insights selector

### DIFF
--- a/linkedin_jobs_scraper/strategies/authenticated_strategy.py
+++ b/linkedin_jobs_scraper/strategies/authenticated_strategy.py
@@ -33,7 +33,7 @@ class Selectors(NamedTuple):
     detailsPanel = '.jobs-search__job-details--container'
     detailsTop = '.jobs-details-top-card'
     details = '.jobs-details__main-content'
-    insights = '[class="mt5 mb2"] > ul > li'  # only one class
+    insights = '.job-details-jobs-unified-top-card__job-insight'  # only one class
     pagination = '.jobs-search-two-pane__pagination'
     privacyAcceptBtn = 'button.artdeco-global-alert__action'
     paginationNextBtn = 'li[data-test-pagination-page-btn].selected + li'  # not used


### PR DESCRIPTION
Linkedin changed the classes on the parent insights element again breaking the selector. I've changed it to use the actual insight class as a selector which will hopefully last longer than the margins on the parent.