### PR TITLE
Fix selector for company link

### DIFF
--- a/linkedin_jobs_scraper/strategies/authenticated_strategy.py
+++ b/linkedin_jobs_scraper/strategies/authenticated_strategy.py
@@ -27,7 +27,7 @@ class Selectors(NamedTuple):
     applyBtn = 'button.jobs-apply-button[role="link"]'
     title = '.artdeco-entity-lockup__title'
     company = '.artdeco-entity-lockup__subtitle'
-    company_link = '.job-details-jobs-unified-top-card__primary-description-container a'
+    company_link = '.job-details-jobs-unified-top-card__company-name a'
     place = '.artdeco-entity-lockup__caption'
     date = 'time'
     description = '.jobs-description'

--- a/linkedin_jobs_scraper/strategies/authenticated_strategy.py
+++ b/linkedin_jobs_scraper/strategies/authenticated_strategy.py
@@ -488,7 +488,7 @@ class AuthenticatedStrategy(Strategy):
                             const el = document.querySelector(arguments[0]);
                             
                             if (el) {
-                                return el.getAttribute("href");
+                                return el.getAttribute("href").split("/life")[0];
                             }
                             else {
                                 return "";


### PR DESCRIPTION
Seems like LinkedIn updated their HTML.
The company URL would be populated with an empty string when using the code from master.

This PR 
- Update the CSS selector to correctly fetch the company url.
- Trim the `/life` suffix from the url to get the root url of the company.
  - Not sure that's the cleanest way to trim the end of a string in javascript. Let me know if you have a better suggestion